### PR TITLE
Fixed an error and a typo.

### DIFF
--- a/notebooks/matrix_matrix.ipynb
+++ b/notebooks/matrix_matrix.ipynb
@@ -712,7 +712,7 @@
     "        iw += 1\n",
     "        w = workers()[iw]\n",
     "        ftr = @spawnat w begin\n",
-    "            Ci = fill(z,l)\n",
+    "            Ci = fill(z,n)\n",
     "            for j in 1:n\n",
     "                for k in 1:l\n",
     "                    @inbounds Ci[j] += Ai[k]*B[k,j]\n",

--- a/notebooks/mpi_tutorial.ipynb
+++ b/notebooks/mpi_tutorial.ipynb
@@ -629,7 +629,7 @@
     "MPI also provides point-to-point communication directives for arbitrary communication between processes. Point-to-point communications are two-sided: there is a sender and a receiver. Here, we will discuss these basic directives:\n",
     "\n",
     "- `MPI.Isend`, and `MPI.Irecv!` (*non-blocking directives*)\n",
-    "- `MPI.Send`, and `MPI.Recv` (*blocking directives*)\n",
+    "- `MPI.Send`, and `MPI.Recv!` (*blocking directives*)\n",
     "\n",
     "\n",
     "Non-blocking directives return immediately and return an `MPI.Request` object. This request object can be queried with functions like `MPI.Wait`. It is mandatory to wait on the request object before reading the receive buffer, or before writing again on the send buffer.\n",


### PR DESCRIPTION
The original `matmul_dist_2!` only executes correctly when A and B are Square Matrices.