### PR TITLE
Fix typo for @pawnat -> @spawnat

### DIFF
--- a/notebooks/julia_distributed.ipynb
+++ b/notebooks/julia_distributed.ipynb
@@ -478,7 +478,7 @@
    "source": [
     "###  `@async` vs `@spawnat`\n",
     "\n",
-    "The relation between `@async` and `@pawnat` is obvious. From the user perspective they work almost in the same way. However,  `@async` generates a task that runs asynchronously in the current process, whereas `@spawnat` executes a task in a remote process in parallel. In both cases, the result is obtained using `fetch`. "
+    "The relation between `@async` and `@spawnat` is obvious. From the user perspective they work almost in the same way. However,  `@async` generates a task that runs asynchronously in the current process, whereas `@spawnat` executes a task in a remote process in parallel. In both cases, the result is obtained using `fetch`. "
    ]
   },
   {
@@ -1445,7 +1445,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.10.0",
+   "display_name": "Julia 1.10.5",
    "language": "julia",
    "name": "julia-1.10"
   },
@@ -1453,7 +1453,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.10.0"
+   "version": "1.10.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed a minor typo in the julia_distributed notebook namely "@pawnat" has been changed to "@spawnat"