### PR TITLE
Typo in julia_basics

### DIFF
--- a/notebooks/julia_basics.ipynb
+++ b/notebooks/julia_basics.ipynb
@@ -874,7 +874,7 @@
    "source": [
     "### Higher-order functions\n",
     "\n",
-    "Higher order functions are functions that take and/or return other functions. And example is the `count` function in Julia.\n",
+    "Higher order functions are functions that take and/or return other functions. An example is the `count` function in Julia.\n",
     "\n",
     "For instance, we can pass a user-defined function to count the number of even elements in an array."
    ]


### PR DESCRIPTION
Fixed typo: "And example is" -> "An example is"